### PR TITLE
Python3 Support

### DIFF
--- a/2lvl_nlte.py
+++ b/2lvl_nlte.py
@@ -5,8 +5,8 @@ from numba import jit
 import sys
 
 font = {'family' : 'normal',                                   
-    	'weight' : 'normal',             
-    	'size'   : 18} 
+        'weight' : 'normal',             
+        'size'   : 18} 
 
 import matplotlib
 matplotlib.rc('font', **font)  
@@ -18,119 +18,119 @@ matplotlib.rc('font', **font)
 
 #-------------------------------------------
 # Short characteristics formal solver:
-@jit('float64[:,:](float64[:],float64[:],float64,float64)',nopython=True)
+@jit(nopython=True)
 def sc_2nd_order(tau, S, mu, I_boundary):
 
-	#first we determine direction:
-	ND = S.shape[0]
-	begin = ND-1
-	end = -1
-	step = -1
-	if (mu<0):
-		begin = 0
-		end = S.shape[0]
-		step = 1
+    #first we determine direction:
+    ND = S.shape[0]
+    begin = ND-1
+    end = -1
+    step = -1
+    if (mu<0):
+        begin = 0
+        end = S.shape[0]
+        step = 1
 
-	I = np.zeros(ND)
-	L = np.zeros(ND)
-	I[begin] = I_boundary
-	#L[begin] = I[begin] / S[begin]
-	
-	for d in range(begin+step,end-step,step):
-		
-		delta_u = (tau[d-step] - tau[d])/mu
-		delta_d = (tau[d] - tau[d+step])/mu
+    I = np.zeros(ND)
+    L = np.zeros(ND)
+    I[begin] = I_boundary
+    #L[begin] = I[begin] / S[begin]
+    
+    for d in range(begin+step,end-step,step):
+        
+        delta_u = (tau[d-step] - tau[d])/mu
+        delta_d = (tau[d] - tau[d+step])/mu
 
-		expd = np.exp(-delta_u)
-		if delta_u <= 0.01:
-			w0=delta_u*(1.-delta_u/2.+delta_u**2/6.-delta_u**3/24.+delta_u**4/120.-delta_u**5/720.+delta_u**6/5040.-delta_u**7/40320.+delta_u**8/362880.)
-			w1=delta_u**2*(0.5-delta_u/3.+delta_u**2/8.-delta_u**3/30.+delta_u**4/144.-delta_u**5/840.+delta_u**6/5760.-delta_u**7/45360.+delta_u**8/403200.)
-			w2=delta_u**3*(1./3.-delta_u/4.+delta_u**2/10.-delta_u**3/36.+delta_u**4/168.-delta_u**5/960.+delta_u**6/6480.-delta_u**7/50400.+delta_u**8/443520.)
-		else:
-			w0 = 1.0 - expd
-			w1 = w0 - delta_u * expd
-			w2 = 2.0 * w1 - delta_u * delta_u * expd
+        expd = np.exp(-delta_u)
+        if delta_u <= 0.01:
+            w0=delta_u*(1.-delta_u/2.+delta_u**2/6.-delta_u**3/24.+delta_u**4/120.-delta_u**5/720.+delta_u**6/5040.-delta_u**7/40320.+delta_u**8/362880.)
+            w1=delta_u**2*(0.5-delta_u/3.+delta_u**2/8.-delta_u**3/30.+delta_u**4/144.-delta_u**5/840.+delta_u**6/5760.-delta_u**7/45360.+delta_u**8/403200.)
+            w2=delta_u**3*(1./3.-delta_u/4.+delta_u**2/10.-delta_u**3/36.+delta_u**4/168.-delta_u**5/960.+delta_u**6/6480.-delta_u**7/50400.+delta_u**8/443520.)
+        else:
+            w0 = 1.0 - expd
+            w1 = w0 - delta_u * expd
+            w2 = 2.0 * w1 - delta_u * delta_u * expd
 
-		psi0 = w0 + (w1 * (delta_u/delta_d - delta_d / delta_u) - w2 * (1.0 / delta_d + 1.0 / delta_u)) / (delta_u + delta_d)
-		psiu = (w2 / delta_u + w1*delta_d/delta_u)/(delta_u+delta_d)
-		psid = (w2 / delta_d - w1 * delta_u/delta_d)/(delta_u+delta_d)
+        psi0 = w0 + (w1 * (delta_u/delta_d - delta_d / delta_u) - w2 * (1.0 / delta_d + 1.0 / delta_u)) / (delta_u + delta_d)
+        psiu = (w2 / delta_u + w1*delta_d/delta_u)/(delta_u+delta_d)
+        psid = (w2 / delta_d - w1 * delta_u/delta_d)/(delta_u+delta_d)
 
-		I[d] = I[d-step]*expd + psiu*S[d-step] + psi0*S[d] + psid*S[d+step]
-		L[d] = psi0
-	#last point is linear:
+        I[d] = I[d-step]*expd + psiu*S[d-step] + psi0*S[d] + psid*S[d+step]
+        L[d] = psi0
+    #last point is linear:
 
-	d = end-step
-	delta_u = (tau[d-step] - tau[d])/mu
-	expd = np.exp(-delta_u)
-	
-	psi0 = 1.0 - 1.0/delta_u * (1.0 - expd)
-	psiu = -expd + 1.0/delta_u * (1.0 - expd)
+    d = end-step
+    delta_u = (tau[d-step] - tau[d])/mu
+    expd = np.exp(-delta_u)
+    
+    psi0 = 1.0 - 1.0/delta_u * (1.0 - expd)
+    psiu = -expd + 1.0/delta_u * (1.0 - expd)
 
-	if (delta_u < 0.01):
-		expd = 1.0 - delta_u + delta_u**2.0 / 2.0 - delta_u**3.0/6.0
-		psi0 = delta_u/2. - delta_u*delta_u/6. + delta_u**3.0 / 24.
-		psiu = delta_u/2. - delta_u**2.0/3. + delta_u**3.0 / 8.
+    if (delta_u < 0.01):
+        expd = 1.0 - delta_u + delta_u**2.0 / 2.0 - delta_u**3.0/6.0
+        psi0 = delta_u/2. - delta_u*delta_u/6. + delta_u**3.0 / 24.
+        psiu = delta_u/2. - delta_u**2.0/3. + delta_u**3.0 / 8.
 
-	I[d] = I[d-step]*expd + psiu*S[d-step] + psi0*S[d]
-	L[d] = psi0
+    I[d] = I[d-step]*expd + psiu*S[d-step] + psi0*S[d]
+    L[d] = psi0
 
-	return np.stack((I,L))
+    return np.stack((I,L))
 
 @jit('float64[:,:](float64[:],float64[:],float64[:],float64[:],float64[:])',nopython=True)
 def calc_lambda_full(tau, mu, wmu, profile, wx):
 
-	ND = tau.shape[0]
-	Lambda_full = np.zeros((ND,ND))
+    ND = tau.shape[0]
+    Lambda_full = np.zeros((ND,ND))
 
-	for d in range(0,ND):
-		S_mock = np.zeros(ND)
-		S_mock[d] = 1.0
-		for m in range(0,mu.shape[0]):
-			for l in range(0,profile.shape[0]):
+    for d in range(0,ND):
+        S_mock = np.zeros(ND)
+        S_mock[d] = 1.0
+        for m in range(0,mu.shape[0]):
+            for l in range(0,profile.shape[0]):
 
-				#outward:
-				Lambda_monoc = sc_2nd_order(tau*profile[l],S_mock,mu[m],0.)
+                #outward:
+                Lambda_monoc = sc_2nd_order(tau*profile[l],S_mock,mu[m],0.)
 
-				Lambda_full[:,d]+=Lambda_monoc[0]*profile[l]*wx[l]*wmu[m]*0.5
-				
-				#inward
-				Lambda_monoc = sc_2nd_order(tau*profile[l],S_mock,-mu[m],0.)
+                Lambda_full[:,d]+=Lambda_monoc[0]*profile[l]*wx[l]*wmu[m]*0.5
+                
+                #inward
+                Lambda_monoc = sc_2nd_order(tau*profile[l],S_mock,-mu[m],0.)
 
-				Lambda_full[:,d]+=Lambda_monoc[0]*profile[l]*wx[l]*wmu[m]*0.5
+                Lambda_full[:,d]+=Lambda_monoc[0]*profile[l]*wx[l]*wmu[m]*0.5
 
-	return Lambda_full
+    return Lambda_full
 
 @jit('float64[:,:](float64[:],float64)',nopython=True)
 def calc_lambda_monoc(tau, mu):
-	ND = tau.shape[0]
-	lambda_monoc = np.zeros((ND,ND))
+    ND = tau.shape[0]
+    lambda_monoc = np.zeros((ND,ND))
 
-	for d in range(0,ND):
-		S_mock = np.zeros(ND)
-		S_mock[d] = 1.0
-			
-		lambda_monoc[:,d] = sc_2nd_order(tau,S_mock,mu,0.)[0]
+    for d in range(0,ND):
+        S_mock = np.zeros(ND)
+        S_mock[d] = 1.0
+            
+        lambda_monoc[:,d] = sc_2nd_order(tau,S_mock,mu,0.)[0]
 
-	return lambda_monoc
+    return lambda_monoc
 
 @jit('float64[:](float64[:],float64[:],float64[:],float64[:],float64[:],float64[:])')
 def calc_anisotropy(tau,mu,wmu,profile,wx,S):
 
-	ND = tau.shape[0]
-	J_02 = np.zeros(ND)
+    ND = tau.shape[0]
+    J_02 = np.zeros(ND)
 
-	for m in range(0,mu.shape[0]):
-		for l in range(0,profile.shape[0]):
+    for m in range(0,mu.shape[0]):
+        for l in range(0,profile.shape[0]):
 
-			#outward:
-			I = sc_2nd_order(tau*profile[l],S,mu[m],S[-1])
-			J_02+=I[0]*profile[l]*wx[l]*wmu[m]*0.5*(1.0-3.*mu[m]*mu[m]) /2.4248
-			
-			#inward
-			I = sc_2nd_order(tau*profile[l],S,-mu[m],0.)
-			J_02+=I[0]*profile[l]*wx[l]*wmu[m]*0.5*(1.0-3.*mu[m]*mu[m]) /2.4248
-	
-	return J_02
+            #outward:
+            I = sc_2nd_order(tau*profile[l],S,mu[m],S[-1])
+            J_02+=I[0]*profile[l]*wx[l]*wmu[m]*0.5*(1.0-3.*mu[m]*mu[m]) /2.4248
+            
+            #inward
+            I = sc_2nd_order(tau*profile[l],S,-mu[m],0.)
+            J_02+=I[0]*profile[l]*wx[l]*wmu[m]*0.5*(1.0-3.*mu[m]*mu[m]) /2.4248
+    
+    return J_02
 
 
 
@@ -141,13 +141,13 @@ def calc_anisotropy(tau,mu,wmu,profile,wx,S):
 @jit('float64[:](float64[:],float64[:],float64,float64[:],float64)',nopython=True)
 def one_full_fs(tau,S,mu,profile,boundary):
 
-	NL = profile.shape[0]
-	I = np.zeros(NL)
+    NL = profile.shape[0]
+    I = np.zeros(NL)
 
-	for l in range(0,NL):
-		I[l] = sc_2nd_order(tau*profile[l],S,mu,boundary)[0,0]
+    for l in range(0,NL):
+        I[l] = sc_2nd_order(tau*profile[l],S,mu,boundary)[0,0]
 
-	return I
+    return I
 
 #-------------------------------------------
 
@@ -193,45 +193,45 @@ mu = np.asarray(mu)
 wmu = np.asarray(wmu)
 
 #Boundary conditions and starting value for the source function
-I_boundary_lower = B[-1];
-I_boundary_upper = 0.0;
+I_boundary_lower = B[-1]
+I_boundary_upper = 0.0
 S = np.copy(B)
 
 # Iteration part
 for iter in range(0,200):
-	
-	# Initialize the scattering integral and local lambda operator
-	J = np.zeros(ND)
-	L = np.zeros(ND)
+    
+    # Initialize the scattering integral and local lambda operator
+    J = np.zeros(ND)
+    L = np.zeros(ND)
 
-	# For each direction and wavelength, calculate the specific monochromatic intensity
-	# and add contributions to the mean intensity and the local operator
-	for m in range(0,NM):
-		for l in range(0,NL):
+    # For each direction and wavelength, calculate the specific monochromatic intensity
+    # and add contributions to the mean intensity and the local operator
+    for m in range(0,NM):
+        for l in range(0,NL):
 
-			#outward
-			ILambda = sc_2nd_order(tau*profile[l]*line_ratio,S,mu[m],B[-1])
+            #outward
+            ILambda = sc_2nd_order(tau*profile[l]*line_ratio,S,mu[m],B[-1])
 
-			J+=ILambda[0]*profile[l]*wx[l]*wmu[m]*0.5
-			L+=ILambda[1]*profile[l]*wx[l]*wmu[m]*0.5
+            J+=ILambda[0]*profile[l]*wx[l]*wmu[m]*0.5
+            L+=ILambda[1]*profile[l]*wx[l]*wmu[m]*0.5
 
-			#inward
-			ILambda = sc_2nd_order(tau*profile[l]*line_ratio,S,-mu[m],0)
+            #inward
+            ILambda = sc_2nd_order(tau*profile[l]*line_ratio,S,-mu[m],0)
 
-			J+=ILambda[0]*profile[l]*wx[l]*wmu[m]*0.5
-			L+=ILambda[1]*profile[l]*wx[l]*wmu[m]*0.5
-	
-	# Correct the source function using local ALI approach:		
-	dS = (eps * B + (1.-eps) * J - S) / (1.-(1.-eps)*L)
+            J+=ILambda[0]*profile[l]*wx[l]*wmu[m]*0.5
+            L+=ILambda[1]*profile[l]*wx[l]*wmu[m]*0.5
+    
+    # Correct the source function using local ALI approach:		
+    dS = (eps * B + (1.-eps) * J - S) / (1.-(1.-eps)*L)
 
-	# Check for change
-	max_change  = np.max(np.abs(dS / S))
-	print (max_change)
+    # Check for change
+    max_change  = np.max(np.abs(dS / S))
+    print(max_change)
 
-	# Correct the source function
-	S += dS
-	if (max_change<1E-4):
-		break;
+    # Correct the source function
+    S += dS
+    if (max_change<1E-4):
+        break
 
 # Calculate the full lambda operator 
 LL = calc_lambda_full(tau*line_ratio,mu,wmu,profile,wx)
@@ -251,12 +251,12 @@ spectra = one_full_fs(tau*line_ratio,S,1.0,detailed_profile,B[-1])
 # at each depth by the response we just calculated and then subtracting the original one
 rf = np.zeros((ND,detailed_profile.shape[0]))
 for d in range(0,ND):
-	rf[d] = one_full_fs(tau*line_ratio,S+dS_dB[:,d]*1E-3,1.0,detailed_profile,B[-1])-spectra
+    rf[d] = one_full_fs(tau*line_ratio,S+dS_dB[:,d]*1E-3,1.0,detailed_profile,B[-1])-spectra
 
 CF = np.zeros((ND,detailed_profile.shape[0]))
 
 for l in range(0,detailed_profile.shape[0]):
-	CF[:,l] = S * np.exp(-tau*line_ratio*detailed_profile[l] * tau*line_ratio*detailed_profile[l])
+    CF[:,l] = S * np.exp(-tau*line_ratio*detailed_profile[l] * tau*line_ratio*detailed_profile[l])
 
 #plot the results.
 plt.figure(figsize=[14,5])

--- a/continuum_scattering.py
+++ b/continuum_scattering.py
@@ -2,31 +2,32 @@ import matplotlib.pyplot as plt
 import numpy as np 
 import astropy.io.fits as fits
 import sys
+from __future__ import print_function
 
 #-------------------------------------------
 # Short characteristics formal solver:
 
 def sc_formal_solver(I_upwind,delta,S_upwind,S_local):
 
-	expd = np.exp(-delta)
-	w_local = 1.0 - 1.0/delta * (1.0 - expd)
-	w_upwind = -expd + 1.0/delta * (1.0 - expd)
+    expd = np.exp(-delta)
+    w_local = 1.0 - 1.0/delta * (1.0 - expd)
+    w_upwind = -expd + 1.0/delta * (1.0 - expd)
 
-	I_local = I_upwind * expd + \
-	w_local * S_local + w_upwind * S_upwind
+    I_local = I_upwind * expd + \
+    w_local * S_local + w_upwind * S_upwind
 
-	return I_local
+    return I_local
 
 def sc_formal_solver_alo(I_upwind,delta,S_upwind,S_local):
 
-	expd = np.exp(-delta)
-	w_local = 1.0 - 1.0/delta * (1.0 - expd)
-	w_upwind = -expd + 1.0/delta * (1.0 - expd)
+    expd = np.exp(-delta)
+    w_local = 1.0 - 1.0/delta * (1.0 - expd)
+    w_upwind = -expd + 1.0/delta * (1.0 - expd)
 
-	I_local = I_upwind * expd + \
-	w_local * S_local + w_upwind * S_upwind
+    I_local = I_upwind * expd + \
+    w_local * S_local + w_upwind * S_upwind
 
-	return I_local, w_local
+    return I_local, w_local
 
 
 
@@ -55,15 +56,15 @@ I_minus = np.zeros(ND)
 I_plus[ND-1] = S[ND-1]
 local_lambda_operator[ND-1] = 1.0
 for d in range (ND-2,-1,-1):
-	I_plus[d], local_alo  = sc_formal_solver_alo(I_plus[d+1],tau[d+1]-tau[d],S[d+1],S[d])
-	local_lambda_operator[d] = local_alo
+    I_plus[d], local_alo  = sc_formal_solver_alo(I_plus[d+1],tau[d+1]-tau[d],S[d+1],S[d])
+    local_lambda_operator[d] = local_alo
 
 
 #Do one formal solution downward:
 I_minus[0] = 0.0
 for d in range (1,ND):
-	I_minus[d], local_alo = sc_formal_solver_alo(I_minus[d-1],tau[d]-tau[d-1],S[d-1],S[d])
-	local_lambda_operator[d] += local_alo
+    I_minus[d], local_alo = sc_formal_solver_alo(I_minus[d-1],tau[d]-tau[d-1],S[d-1],S[d])
+    local_lambda_operator[d] += local_alo
 
 local_lambda_operator[:] *= 0.5
 
@@ -104,31 +105,31 @@ N_iter = 1000
 rel_diff = np.zeros(N_iter)
 
 for i in range(0,N_iter):
-	I_plus[ND-1] = S[ND-1]
-	local_lambda_operator[ND-1] = 1.0
-	for d in range (ND-2,-1,-1):
-		I_plus[d], local_alo  = sc_formal_solver_alo(I_plus[d+1],tau[d+1]-tau[d],S[d+1],S[d])
-		local_lambda_operator[d] = local_alo
+    I_plus[ND-1] = S[ND-1]
+    local_lambda_operator[ND-1] = 1.0
+    for d in range (ND-2,-1,-1):
+        I_plus[d], local_alo  = sc_formal_solver_alo(I_plus[d+1],tau[d+1]-tau[d],S[d+1],S[d])
+        local_lambda_operator[d] = local_alo
 
-	I_minus[0] = 0.0
-	for d in range (1,ND):
-		I_minus[d], local_alo = sc_formal_solver_alo(I_minus[d-1],tau[d]-tau[d-1],S[d-1],S[d])
-		local_lambda_operator[d] += local_alo
+    I_minus[0] = 0.0
+    for d in range (1,ND):
+        I_minus[d], local_alo = sc_formal_solver_alo(I_minus[d-1],tau[d]-tau[d-1],S[d-1],S[d])
+        local_lambda_operator[d] += local_alo
 
-	local_lambda_operator[:] *= 0.5
+    local_lambda_operator[:] *= 0.5
 
-	S_old = S #to evaluate change
-	J = (I_minus + I_plus)*0.5
-	S = eps * B + (1.0-eps)*(I_minus + I_plus) * 0.5
-	#S = (eps * B + (1.0-eps) * (J- local_lambda_operator * S)) / (1.0 - (1.0-eps)*local_lambda_operator)
-	
-	plt.plot(logtau,S)
-	rel_diff[i] = np.abs((S[0]-S_old[0]) / S_old[0])
-	print 'Iteration #',i
-	if (rel_diff[i] < 1E-5):
-		break
+    S_old = S #to evaluate change
+    J = (I_minus + I_plus)*0.5
+    S = eps * B + (1.0-eps)*(I_minus + I_plus) * 0.5
+    #S = (eps * B + (1.0-eps) * (J- local_lambda_operator * S)) / (1.0 - (1.0-eps)*local_lambda_operator)
+    
+    plt.plot(logtau,S)
+    rel_diff[i] = np.abs((S[0]-S_old[0]) / S_old[0])
+    print('Iteration #', i)
+    if (rel_diff[i] < 1E-5):
+        break
 
-print I_plus[0]
+print(I_plus[0])
 
 plt.savefig('S_change.png')
 

--- a/rtfunctions.py
+++ b/rtfunctions.py
@@ -5,8 +5,8 @@ from numba import jit
 import sys
 
 font = {'family' : 'normal',                                   
-    	'weight' : 'normal',             
-    	'size'   : 18} 
+        'weight' : 'normal',             
+        'size'   : 18} 
 
 import matplotlib
 matplotlib.rc('font', **font)  
@@ -18,119 +18,119 @@ matplotlib.rc('font', **font)
 
 #-------------------------------------------
 # Short characteristics formal solver:
-@jit('float64[:,:](float64[:],float64[:],float64,float64)',nopython=True)
+@jit(nopython=True)
 def sc_2nd_order(tau, S, mu, I_boundary):
 
-	#first we determine direction:
-	ND = S.shape[0]
-	begin = ND-1
-	end = -1
-	step = -1
-	if (mu<0):
-		begin = 0
-		end = S.shape[0]
-		step = 1
+    #first we determine direction:
+    ND = S.shape[0]
+    begin = ND-1
+    end = -1
+    step = -1
+    if (mu<0):
+        begin = 0
+        end = S.shape[0]
+        step = 1
 
-	I = np.zeros(ND)
-	L = np.zeros(ND)
-	I[begin] = I_boundary
-	#L[begin] = I[begin] / S[begin]
-	
-	for d in range(begin+step,end-step,step):
-		
-		delta_u = (tau[d-step] - tau[d])/mu
-		delta_d = (tau[d] - tau[d+step])/mu
+    I = np.zeros(ND)
+    L = np.zeros(ND)
+    I[begin] = I_boundary
+    #L[begin] = I[begin] / S[begin]
+    
+    for d in range(begin+step,end-step,step):
+        
+        delta_u = (tau[d-step] - tau[d])/mu
+        delta_d = (tau[d] - tau[d+step])/mu
 
-		expd = np.exp(-delta_u)
-		if delta_u <= 0.01:
-			w0=delta_u*(1.-delta_u/2.+delta_u**2/6.-delta_u**3/24.+delta_u**4/120.-delta_u**5/720.+delta_u**6/5040.-delta_u**7/40320.+delta_u**8/362880.)
-			w1=delta_u**2*(0.5-delta_u/3.+delta_u**2/8.-delta_u**3/30.+delta_u**4/144.-delta_u**5/840.+delta_u**6/5760.-delta_u**7/45360.+delta_u**8/403200.)
-			w2=delta_u**3*(1./3.-delta_u/4.+delta_u**2/10.-delta_u**3/36.+delta_u**4/168.-delta_u**5/960.+delta_u**6/6480.-delta_u**7/50400.+delta_u**8/443520.)
-		else:
-			w0 = 1.0 - expd
-			w1 = w0 - delta_u * expd
-			w2 = 2.0 * w1 - delta_u * delta_u * expd
+        expd = np.exp(-delta_u)
+        if delta_u <= 0.01:
+            w0=delta_u*(1.-delta_u/2.+delta_u**2/6.-delta_u**3/24.+delta_u**4/120.-delta_u**5/720.+delta_u**6/5040.-delta_u**7/40320.+delta_u**8/362880.)
+            w1=delta_u**2*(0.5-delta_u/3.+delta_u**2/8.-delta_u**3/30.+delta_u**4/144.-delta_u**5/840.+delta_u**6/5760.-delta_u**7/45360.+delta_u**8/403200.)
+            w2=delta_u**3*(1./3.-delta_u/4.+delta_u**2/10.-delta_u**3/36.+delta_u**4/168.-delta_u**5/960.+delta_u**6/6480.-delta_u**7/50400.+delta_u**8/443520.)
+        else:
+            w0 = 1.0 - expd
+            w1 = w0 - delta_u * expd
+            w2 = 2.0 * w1 - delta_u * delta_u * expd
 
-		psi0 = w0 + (w1 * (delta_u/delta_d - delta_d / delta_u) - w2 * (1.0 / delta_d + 1.0 / delta_u)) / (delta_u + delta_d)
-		psiu = (w2 / delta_u + w1*delta_d/delta_u)/(delta_u+delta_d)
-		psid = (w2 / delta_d - w1 * delta_u/delta_d)/(delta_u+delta_d)
+        psi0 = w0 + (w1 * (delta_u/delta_d - delta_d / delta_u) - w2 * (1.0 / delta_d + 1.0 / delta_u)) / (delta_u + delta_d)
+        psiu = (w2 / delta_u + w1*delta_d/delta_u)/(delta_u+delta_d)
+        psid = (w2 / delta_d - w1 * delta_u/delta_d)/(delta_u+delta_d)
 
-		I[d] = I[d-step]*expd + psiu*S[d-step] + psi0*S[d] + psid*S[d+step]
-		L[d] = psi0
-	#last point is linear:
+        I[d] = I[d-step]*expd + psiu*S[d-step] + psi0*S[d] + psid*S[d+step]
+        L[d] = psi0
+    #last point is linear:
 
-	d = end-step
-	delta_u = (tau[d-step] - tau[d])/mu
-	expd = np.exp(-delta_u)
-	
-	psi0 = 1.0 - 1.0/delta_u * (1.0 - expd)
-	psiu = -expd + 1.0/delta_u * (1.0 - expd)
+    d = end-step
+    delta_u = (tau[d-step] - tau[d])/mu
+    expd = np.exp(-delta_u)
+    
+    psi0 = 1.0 - 1.0/delta_u * (1.0 - expd)
+    psiu = -expd + 1.0/delta_u * (1.0 - expd)
 
-	if (delta_u < 0.01):
-		expd = 1.0 - delta_u + delta_u**2.0 / 2.0 - delta_u**3.0/6.0
-		psi0 = delta_u/2. - delta_u*delta_u/6. + delta_u**3.0 / 24.
-		psiu = delta_u/2. - delta_u**2.0/3. + delta_u**3.0 / 8.
+    if (delta_u < 0.01):
+        expd = 1.0 - delta_u + delta_u**2.0 / 2.0 - delta_u**3.0/6.0
+        psi0 = delta_u/2. - delta_u*delta_u/6. + delta_u**3.0 / 24.
+        psiu = delta_u/2. - delta_u**2.0/3. + delta_u**3.0 / 8.
 
-	I[d] = I[d-step]*expd + psiu*S[d-step] + psi0*S[d]
-	L[d] = psi0
+    I[d] = I[d-step]*expd + psiu*S[d-step] + psi0*S[d]
+    L[d] = psi0
 
-	return np.stack((I,L))
+    return np.stack((I,L))
 
-@jit('float64[:,:](float64[:],float64[:],float64[:],float64[:],float64[:])',nopython=True)
+@jit(nopython=True)
 def calc_lambda_full(tau, mu, wmu, profile, wx):
 
-	ND = tau.shape[0]
-	Lambda_full = np.zeros((ND,ND))
+    ND = tau.shape[0]
+    Lambda_full = np.zeros((ND,ND))
 
-	for d in range(0,ND):
-		S_mock = np.zeros(ND)
-		S_mock[d] = 1.0
-		for m in range(0,mu.shape[0]):
-			for l in range(0,profile.shape[0]):
+    for d in range(0,ND):
+        S_mock = np.zeros(ND)
+        S_mock[d] = 1.0
+        for m in range(0,mu.shape[0]):
+            for l in range(0,profile.shape[0]):
 
-				#outward:
-				Lambda_monoc = sc_2nd_order(tau*profile[l],S_mock,mu[m],0.)
+                #outward:
+                Lambda_monoc = sc_2nd_order(tau*profile[l],S_mock,mu[m],0.)
 
-				Lambda_full[:,d]+=Lambda_monoc[0]*profile[l]*wx[l]*wmu[m]*0.5
-				
-				#inward
-				Lambda_monoc = sc_2nd_order(tau*profile[l],S_mock,-mu[m],0.)
+                Lambda_full[:,d]+=Lambda_monoc[0]*profile[l]*wx[l]*wmu[m]*0.5
+                
+                #inward
+                Lambda_monoc = sc_2nd_order(tau*profile[l],S_mock,-mu[m],0.)
 
-				Lambda_full[:,d]+=Lambda_monoc[0]*profile[l]*wx[l]*wmu[m]*0.5
+                Lambda_full[:,d]+=Lambda_monoc[0]*profile[l]*wx[l]*wmu[m]*0.5
 
-	return Lambda_full
+    return Lambda_full
 
-@jit('float64[:,:](float64[:],float64)',nopython=True)
+@jit(nopython=True)
 def calc_lambda_monoc(tau, mu):
-	ND = tau.shape[0]
-	lambda_monoc = np.zeros((ND,ND))
+    ND = tau.shape[0]
+    lambda_monoc = np.zeros((ND,ND))
 
-	for d in range(0,ND):
-		S_mock = np.zeros(ND)
-		S_mock[d] = 1.0
-			
-		lambda_monoc[:,d] = sc_2nd_order(tau,S_mock,mu,0.)[0]
+    for d in range(0,ND):
+        S_mock = np.zeros(ND)
+        S_mock[d] = 1.0
+            
+        lambda_monoc[:,d] = sc_2nd_order(tau,S_mock,mu,0.)[0]
 
-	return lambda_monoc
+    return lambda_monoc
 
-@jit('float64[:](float64[:],float64[:],float64[:],float64[:],float64[:],float64[:])')
+@jit(nopython=True)
 def calc_anisotropy(tau,mu,wmu,profile,wx,S):
 
-	ND = tau.shape[0]
-	J_02 = np.zeros(ND)
+    ND = tau.shape[0]
+    J_02 = np.zeros(ND)
 
-	for m in range(0,mu.shape[0]):
-		for l in range(0,profile.shape[0]):
+    for m in range(0,mu.shape[0]):
+        for l in range(0,profile.shape[0]):
 
-			#outward:
-			I = sc_2nd_order(tau*profile[l],S,mu[m],S[-1])
-			J_02+=I[0]*profile[l]*wx[l]*wmu[m]*0.5*(1.0-3.*mu[m]*mu[m]) /2.4248
-			
-			#inward
-			I = sc_2nd_order(tau*profile[l],S,-mu[m],0.)
-			J_02+=I[0]*profile[l]*wx[l]*wmu[m]*0.5*(1.0-3.*mu[m]*mu[m]) /2.4248
-	
-	return J_02
+            #outward:
+            I = sc_2nd_order(tau*profile[l],S,mu[m],S[-1])
+            J_02+=I[0]*profile[l]*wx[l]*wmu[m]*0.5*(1.0-3.*mu[m]*mu[m]) /2.4248
+            
+            #inward
+            I = sc_2nd_order(tau*profile[l],S,-mu[m],0.)
+            J_02+=I[0]*profile[l]*wx[l]*wmu[m]*0.5*(1.0-3.*mu[m]*mu[m]) /2.4248
+    
+    return J_02
 
 
 
@@ -138,13 +138,13 @@ def calc_anisotropy(tau,mu,wmu,profile,wx,S):
 #def calc_anisotropy_response(tau,mu,wmu,profile,wx,dS_dB):
 
 
-@jit('float64[:](float64[:],float64[:],float64,float64[:],float64)',nopython=True)
+@jit(nopython=True)
 def one_full_fs(tau,S,mu,profile,boundary):
 
-	NL = profile.shape[0]
-	I = np.zeros(NL)
+    NL = profile.shape[0]
+    I = np.zeros(NL)
 
-	for l in range(0,NL):
-		I[l] = sc_2nd_order(tau*profile[l],S,mu,boundary)[0,0]
+    for l in range(0,NL):
+        I[l] = sc_2nd_order(tau*profile[l],S,mu,boundary)[0,0]
 
-	return I
+    return I


### PR DESCRIPTION
as Python2 is End of Life as of 01/01/2020 and it's best if this 'just runs' in modern python. Also converted indentation to spaces as it plays better with most editors. The explicit typing in the numba jit statements was removed as it typically decreases performance -- this is not initially intuitive, but it's due to `float64[:,:]` actually implicitly indicating that the array may not be contiguous. To force a C-contiguous array `float64[:,::1]` can be used but not specifying will lead to the most efficient code being generated for whatever combination of contiguous and possibly non-contiguous slices that are encountered at runtime.